### PR TITLE
slp: Don't explode if there is some padding after end-of-row

### DIFF
--- a/genie/slp/__init__.py
+++ b/genie/slp/__init__.py
@@ -162,7 +162,11 @@ class Frame(object):
                         y += 1
                         x = left_boundaries[y]
                     if stream.tell() != command_offsets[y]:
-                        raise Exception('%d but should be %d' % (stream.tell(), command_offsets[y]))
+                        # not an error, but excessive padding might suggest something is slightly wrong!
+                        print "Warning: line %d has %d bytes of air after commands" % (y - 1,
+                                command_offsets[y] - stream.tell())
+                        # get ourselves aligned again
+                        stream.seek(command_offsets[y])
             elif fourbit == 0x06:
                 # player colors
                 amount = _get_4ornext(opcode)


### PR DESCRIPTION
Many real SLPs (as found in SWGB/GRAPHICS.DRS) have a bit of air after
the end-of-row opcode. This isn't an error.

Signed-off-by: Chris Forbes chrisf@ijw.co.nz
