### PR TITLE
show: raise ValueError if a filename isn't given to 'show' command

### DIFF
--- a/browse_slp.py
+++ b/browse_slp.py
@@ -17,6 +17,9 @@ from genie.slp.pyglet_adapter import PygletAdapter, load_aoe_animations
 BAR_HEIGHT = 12
 
 def _get_resource_id(filename):
+    if not filename:
+        return -1
+
     return int(filename.split('.')[0])
 
 class SLPLoader(object):
@@ -302,11 +305,20 @@ class SLPBrowser(cmd.Cmd):
         """
             Show the given SLP file!
         """
+        success = False
         try:
-            print HELP_SHOW % name
             self.loader.show_filename(name)
+            success = True
+        except KeyError:
+            if not name:
+                print "No filename given."
+            else:
+                print "File %s does not exist." % name
         except:
             traceback.print_exc()
+
+        if success:
+            print HELP_SHOW % name
 
     def do_showanim(self, name):
         """


### PR DESCRIPTION
Turns

``` python
genie> help

Documented commands (type help <topic>):
========================================
drs     help  palette  player  saveall    show
export  ls    play     save    savefirst  showanim

genie> show
Now showing ''. Keys:
        q       return to prompt
        +/-     zoom
        a       show the frame hotspot
        arrow keys      to cycle between frames

Traceback (most recent call last):
  File "browse_slp.py", line 307, in do_show
    self.loader.show_filename(name)
  File "browse_slp.py", line 55, in show_filename
    resource_id = _get_resource_id(filename)
  File "browse_slp.py", line 20, in _get_resource_id
    return int(filename.split('.')[0])
ValueError: invalid literal for int() with base 10: ''

genie>
```

into

``` python
genie> help

Documented commands (type help <topic>):
========================================
drs     help  palette  player  saveall    show
export  ls    play     save    savefirst  showanim

genie> show
Now showing ''. Keys:
        q       return to prompt
        +/-     zoom
        a       show the frame hotspot
        arrow keys      to cycle between frames

Traceback (most recent call last):
  File "browse_slp.py", line 313, in do_show
    self.loader.show_filename(name)
  File "browse_slp.py", line 60, in show_filename
    raise ValueError("no filename given")
ValueError: no filename given

genie>
```

If you instead want me to raise elsewhere (such as `do_show`) I can do that.
Or we could give the user a message back indicating incorrect usage.

Just let me know.
