### PR TITLE
Refactor zoom methods, fix zooming in not working.

### DIFF
--- a/browse_slp.py
+++ b/browse_slp.py
@@ -140,20 +140,28 @@ class BaseSLPView(object):
     def draw_hotspot(self):
         raise NotImplementedError()
 
-    def zoom(self, factor):
-        self.sprite.scale += factor * 0.2
+    def zoom_with_factor(self, factor, factor_multiplier=0.2):
+        factor *= factor_multiplier
+        self.zoom_to(self.sprite.scale + factor)
+
+    def zoom_to(self, scale):
+        scale = abs(scale)
+        self.sprite.scale = scale
         self.resize_window()
 
     def on_key_press(self, symbol, modifiers):
-        if symbol == pyglet.window.key.Q:
+        key = pyglet.window.key
+        if symbol == key.Q:
             self.window.close()
             pyglet.app.exit()
-        if symbol == pyglet.window.key.A:
+        if symbol == key.A:
             self.show_hotspot = not self.show_hotspot
-        if symbol == pyglet.window.key.PLUS:
-            self.zoom(1)
-        if symbol == pyglet.window.key.MINUS:
-            self.zoom(-1)
+        if symbol == key.PLUS:
+            self.zoom_with_factor(1)
+        if symbol == key.MINUS:
+            self.zoom_with_factor(-1)
+        if symbol == key._0:
+            self.zoom_to(1)
 
 class SLPView(BaseSLPView):
     """
@@ -243,7 +251,7 @@ class AnimatedSLPView(BaseSLPView):
 
 HELP_SHOW = """Now showing %r. Keys:
 \tq\treturn to prompt
-\t+/-\tzoom
+\t+/-/0\tzoom
 \ta\tshow the frame hotspot
 \tarrow keys\tto cycle between frames
 """


### PR DESCRIPTION
Referenced https://pythonhosted.org/pyglet/api/pyglet.window.key-module.html.
Closes #8.

Improves usability and the code is a bit more straight-forward (as much as it can be with pyglet's keyboard handling).
